### PR TITLE
[AV-5225] BULK API ETL pull is failing when the field size is large

### DIFF
--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -539,6 +539,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
+        csv.field_size_limit(sys.maxsize)
         reader = csv.reader(tf, delimiter=",", quotechar='"')
         for row in reader:
             line_number += 1
@@ -559,6 +560,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
+        csv.field_size_limit(sys.maxsize)
         reader = csv.reader(tf, delimiter=",", quotechar='"')
         for row in reader:
             line_number += 1

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -14,7 +14,6 @@ import StringIO
 import re
 import time
 import csv
-import sys
 from . import bulk_states
 
 UploadResult = namedtuple('UploadResult', 'id success created error')
@@ -469,10 +468,8 @@ class SalesforceBulk(object):
         if not parse_csv:
             iterator = resp.iter_lines()
         else:
-            print("---------------Testing---------------------")
-            csv.field_size_limit(sys.maxsize)
             iterator = csv.reader((x.replace('\0', '') for x in resp.iter_lines()), delimiter=',',
-                                  quotechar='"')
+                                  quotechar= csv.QUOTE_NONE)
 
         BATCH_SIZE = 5000
         for i, line in enumerate(iterator):
@@ -539,8 +536,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        csv.field_size_limit(sys.maxsize)
-        reader = csv.reader(tf, delimiter=",", quotechar='"')
+        reader = csv.reader(tf, delimiter=",", quotechar= csv.QUOTE_NONE)
         for row in reader:
             line_number += 1
             records.append(UploadResult(*row))
@@ -560,8 +556,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        csv.field_size_limit(sys.maxsize)
-        reader = csv.reader(tf, delimiter=",", quotechar='"')
+        reader = csv.reader(tf, delimiter=",", quotechar= csv.QUOTE_NONE)
         for row in reader:
             line_number += 1
             records.append(row)

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -468,8 +468,9 @@ class SalesforceBulk(object):
         if not parse_csv:
             iterator = resp.iter_lines()
         else:
+            csv.field_size_limit(100000000)
             iterator = csv.reader((x.replace('\0', '') for x in resp.iter_lines()), delimiter=',',
-                                  quotechar= csv.QUOTE_NONE)
+                                  quoting=csv.QUOTE_NONE)
 
         BATCH_SIZE = 5000
         for i, line in enumerate(iterator):
@@ -536,7 +537,8 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        reader = csv.reader(tf, delimiter=",", quotechar= csv.QUOTE_NONE)
+        csv.field_size_limit(100000000)
+        reader = csv.reader(tf, delimiter=",", quoting=csv.QUOTE_NONE)
         for row in reader:
             line_number += 1
             records.append(UploadResult(*row))
@@ -556,7 +558,8 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        reader = csv.reader(tf, delimiter=",", quotechar= csv.QUOTE_NONE)
+        csv.field_size_limit(100000000)
+        reader = csv.reader(tf, delimiter=",", quoting=csv.QUOTE_NONE)
         for row in reader:
             line_number += 1
             records.append(row)

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -14,7 +14,8 @@ import StringIO
 import re
 import time
 import csv
-
+import sys
+csv.field_size_limit(sys.maxsize)
 from . import bulk_states
 
 UploadResult = namedtuple('UploadResult', 'id success created error')

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -434,7 +434,7 @@ class SalesforceBulk(object):
         """
         Gets result ids and generates each result set from the batch and returns it
         as an generator fetching the next result set when needed
-        
+
         Args:
             batch_id: id of batch
             job_id: id of job, if not provided, it will be looked up

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -15,7 +15,6 @@ import re
 import time
 import csv
 import sys
-csv.field_size_limit(sys.maxsize)
 from . import bulk_states
 
 UploadResult = namedtuple('UploadResult', 'id success created error')
@@ -470,6 +469,8 @@ class SalesforceBulk(object):
         if not parse_csv:
             iterator = resp.iter_lines()
         else:
+            print("---------------Testing---------------------")
+            csv.field_size_limit(sys.maxsize)
             iterator = csv.reader((x.replace('\0', '') for x in resp.iter_lines()), delimiter=',',
                                   quotechar='"')
 

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -434,6 +434,7 @@ class SalesforceBulk(object):
         """
         Gets result ids and generates each result set from the batch and returns it
         as an generator fetching the next result set when needed
+        
         Args:
             batch_id: id of batch
             job_id: id of job, if not provided, it will be looked up

--- a/salesforce_bulk/salesforce_bulk.py
+++ b/salesforce_bulk/salesforce_bulk.py
@@ -14,6 +14,7 @@ import StringIO
 import re
 import time
 import csv
+csv.field_size_limit(1000000)
 from . import bulk_states
 
 UploadResult = namedtuple('UploadResult', 'id success created error')
@@ -433,7 +434,6 @@ class SalesforceBulk(object):
         """
         Gets result ids and generates each result set from the batch and returns it
         as an generator fetching the next result set when needed
-
         Args:
             batch_id: id of batch
             job_id: id of job, if not provided, it will be looked up
@@ -468,9 +468,8 @@ class SalesforceBulk(object):
         if not parse_csv:
             iterator = resp.iter_lines()
         else:
-            csv.field_size_limit(100000000)
             iterator = csv.reader((x.replace('\0', '') for x in resp.iter_lines()), delimiter=',',
-                                  quoting=csv.QUOTE_NONE)
+                                  quotechar='"')
 
         BATCH_SIZE = 5000
         for i, line in enumerate(iterator):
@@ -537,8 +536,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        csv.field_size_limit(100000000)
-        reader = csv.reader(tf, delimiter=",", quoting=csv.QUOTE_NONE)
+        reader = csv.reader(tf, delimiter=",", quotechar='"')
         for row in reader:
             line_number += 1
             records.append(UploadResult(*row))
@@ -558,8 +556,7 @@ class SalesforceBulk(object):
         records = []
         line_number = 0
         col_names = []
-        csv.field_size_limit(100000000)
-        reader = csv.reader(tf, delimiter=",", quoting=csv.QUOTE_NONE)
+        reader = csv.reader(tf, delimiter=",", quotechar='"')
         for row in reader:
             line_number += 1
             records.append(row)


### PR DESCRIPTION
The default field size limit is 131072 
Updated the field size limit to 1000000